### PR TITLE
Added function get_config() - ownCloud config information

### DIFF
--- a/owncloud/__init__.py
+++ b/owncloud/__init__.py
@@ -468,6 +468,11 @@ class Client():
         raise ResponseError(res)
 
     def get_config(self):
+        """Returns ownCloud config information as JSON
+        :returns: JSON object with config information
+            e.g. {'website': 'ownCloud', 'ssl': 'false', 'host': 'cloud.example.com', 'version': '1.7', 'contact': ''}
+        :raises: ResponseError in case an HTTP error status was returned
+        """
 	path = 'config'
 	res = self.__make_ocs_request(
 		'GET',


### PR DESCRIPTION
It's just a function to get ownCloud config information - returns JSON, e.g.:
{'website': 'ownCloud', 'ssl': 'false', 'host': 'cloud.example.com', 'version': '1.7', 'contact': ''}
