### PR TITLE
Added single_session argument for OC5 workaround

### DIFF
--- a/owncloud/__init__.py
+++ b/owncloud/__init__.py
@@ -123,6 +123,8 @@ class Client():
 
         :param url: URL of the target ownCloud instance
         :param verify_certs: True (default) to verify SSL certificates, False otherwise
+        :param single_session: True to use a single session for every call
+            (default, recommended), False to reauthenticate every call (use with ownCloud 5)
         :param debug: set to True to print debugging messages to stdout, defaults to False
         """
         if not url[-1] == '/':
@@ -132,6 +134,7 @@ class Client():
         self.__session = None
         self.__debug = kwargs.get('debug', False)
         self.__verify_certs = kwargs.get('verify_certs', True)
+        self.__single_session = kwargs.get('single_session', True);
 
         url_components = urlparse.urlparse(url)
         self.__davpath = url_components.path + 'remote.php/webdav'
@@ -152,9 +155,9 @@ class Client():
         # TODO: use another path to prevent that the server renders the file list page
         res = self.__session.get(self.url)
         if res.status_code == 200:
-            # Remove auth, no need to re-auth every call
-            # so sending the auth every time for now
-            self.__session.auth = None
+            if self.__single_session:
+                # Keep the same session, no need to re-auth every call
+                self.__session.auth = None
             return
         self.__session.close()
         self.__session = None

--- a/owncloud/test/config.py
+++ b/owncloud/test/config.py
@@ -17,6 +17,8 @@ Config = {
     # remote root path to use for testing 
     'test_root': 'pyoctestroot%s' % test_id,
     # app name to use when testing privatedata API
-    'app_name': 'pyocclient_test%s' % test_id
+    'app_name': 'pyocclient_test%s' % test_id,
+    # single session mode (only set to False for ownCloud 5)
+    'single_session': True
 }
 

--- a/owncloud/test/test.py
+++ b/owncloud/test/test.py
@@ -17,7 +17,8 @@ class TestFileAccess(unittest.TestCase):
     def setUp(self):
         self.temp_dir = tempfile.gettempdir() + '/pyocclient_test%s/' % int(time.time())
         os.mkdir(self.temp_dir)
-        self.client = owncloud.Client(Config['owncloud_url'])
+
+        self.client = owncloud.Client(Config['owncloud_url'], single_session = Config['single_session'])
         self.client.login(Config['owncloud_login'], Config['owncloud_password'])
         self.test_root = Config['test_root']
         if not self.test_root[-1] == '/':
@@ -233,7 +234,7 @@ class TestFileAccess(unittest.TestCase):
 
 class TestPrivateDataAccess(unittest.TestCase):
     def setUp(self):
-        self.client = owncloud.Client(Config['owncloud_url'])
+        self.client = owncloud.Client(Config['owncloud_url'], single_session = Config['single_session'])
         self.client.login(Config['owncloud_login'], Config['owncloud_password'])
         self.app_name = Config['app_name']
 


### PR DESCRIPTION
The OCS API in OC5 has trouble when reusing the same session.

This fix adds an argument single_session that can be set to False to
force reauthenticating for every call (not recommended).

Fixes #8 

@Gomez please sanity check this workaround.
Makes the client work with OC 5.
