### PR TITLE
Reduce requested version for requests module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     description='Python client library for ownCloud',
     long_description=long_description,
     install_requires=[
-        "requests >= 2.0.1",
+        "requests >= 1.2.3",
     ],
 	classifiers=[
 		'Programming Language :: Python',


### PR DESCRIPTION
I noticed that I've been working with 1.2.3 on my laptop all along and pyocclient still seems to work correctly (unit tests pass) with that version. My other computer had 2.3.0.

So I suggest we reduce the version of "requests" to 1.2.3.

@Gomez @soalhn what do you think ?
