### PR TITLE
is_shared() fixes

### DIFF
--- a/owncloud/owncloud.py
+++ b/owncloud/owncloud.py
@@ -493,7 +493,6 @@ class Client():
         self.file_info(path)
         try:
             result = self.get_shares(path)
-            print "[debug] is_shared - result: %s" % result
             if result:
                 return (len(result) > 0)
         except ResponseError as e:

--- a/owncloud/test/test.py
+++ b/owncloud/test/test.py
@@ -249,6 +249,7 @@ class TestFileAccess(unittest.TestCase):
 
         self.client.share_file_with_link(path)
         self.assertTrue(self.client.is_shared(path))
+        self.assertTrue(self.client.delete(path))
 
     def test_get_shares_non_existing_path(self):
         """Test get_shares - path does not exist"""


### PR DESCRIPTION
We can assume that the path is not shared only when the path exist (file or directory) and get_shares() thrown 404 exception.
