### PR TITLE
Fix chunk count

### DIFF
--- a/owncloud/owncloud.py
+++ b/owncloud/owncloud.py
@@ -418,11 +418,11 @@ class Client():
 
         chunk_count = size / chunk_size
 
-        if chunk_count > 1:
-            headers['OC-CHUNKED'] = 1
-
         if size % chunk_size > 0:
             chunk_count += 1
+
+        if chunk_count > 1:
+            headers['OC-CHUNKED'] = 1
        
         for chunk_index in range(0, chunk_count):
             data = file_handle.read(chunk_size)

--- a/owncloud/test/test.py
+++ b/owncloud/test/test.py
@@ -125,6 +125,18 @@ class TestFileAccess(unittest.TestCase):
         self.assertIsNotNone(file_info)
         self.assertEquals(file_info.get_size(), 2 * 1024)
 
+    def test_upload_two_chunks(self):
+        """Test chunked upload with two chunks"""
+        temp_file = self.temp_dir + 'pyoctest.dat'
+        self.__create_file(temp_file, 18 * 1024 * 1024)
+        self.assertTrue(self.client.put_file(self.test_root + 'chunk_test.dat', temp_file))
+        os.unlink(temp_file)
+
+        file_info = self.client.file_info(self.test_root + 'chunk_test.dat')
+
+        self.assertIsNotNone(file_info)
+        self.assertEquals(file_info.get_size(), 18 * 1024 * 1024)
+
     def test_upload_big_file(self):
         """Test chunked upload"""
         temp_file = self.temp_dir + 'pyoctest.dat'


### PR DESCRIPTION
When a file only has two chunks, the count was wrong and the header was
missing

TODO:
- [x] add unit test with 2 chunks
