### PR TITLE
Use WebDAV endpoint for authentication

### DIFF
--- a/owncloud/owncloud.py
+++ b/owncloud/owncloud.py
@@ -176,7 +176,9 @@ class Client():
         self.__session.verify = self.__verify_certs
         self.__session.auth = (user_id, password)
         # TODO: use another path to prevent that the server renders the file list page
-        res = self.__session.get(self.url)
+        #res = self.__session.get(self.url)
+        # using web dav endpoint instead due to server bugs
+        res = self.__session.get(self.__webdav_url)
         if res.status_code == 200:
             if self.__single_session:
                 # Keep the same session, no need to re-auth every call


### PR DESCRIPTION
Due to https://github.com/owncloud/core/issues/11129 the login hook is not triggered and breaks encryption.

This workaround uses the WebDAV endpoint for basic auth instead of the root.
