### PR TITLE
Fix open to always use binary mode, for Windows

### DIFF
--- a/docs/source/CHANGES.rst
+++ b/docs/source/CHANGES.rst
@@ -8,6 +8,7 @@ Changelog
 - Travis integration [Gomez]
 - Added session handling workaround for OC 5 [PVince81]
 - Fixed many issues related to unicode path names [PVince81]
+- Client now works properly on Windows [PVince81]
 
 0.1
 ---

--- a/owncloud/owncloud.py
+++ b/owncloud/owncloud.py
@@ -260,7 +260,7 @@ class Client():
                 # local_file = res.headers['content-disposition']
                 local_file = os.path.basename(remote_path)
 
-            file_handle = open(local_file, 'w', 8192)
+            file_handle = open(local_file, 'wb', 8192)
             for chunk in res.iter_content(8192):
                 file_handle.write(chunk)
             file_handle.close()
@@ -288,7 +288,7 @@ class Client():
                 # targetFile = res.headers['content-disposition']
                 local_file = os.path.basename(remote_path)
 
-            file_handle = open(local_file, 'w', 8192)
+            file_handle = open(local_file, 'wb', 8192)
             for chunk in res.iter_content(8192):
                 file_handle.write(chunk)
             file_handle.close()
@@ -333,7 +333,7 @@ class Client():
 
         if remote_path[-1] == '/':
             remote_path += os.path.basename(local_source_file)
-        file_handle = open(local_source_file, 'r', 8192)
+        file_handle = open(local_source_file, 'rb', 8192)
         res = self.__make_dav_request(
                 'PUT',
                 remote_path,
@@ -399,7 +399,7 @@ class Client():
 
         stat_result = os.stat(local_source_file)
 
-        file_handle = open(local_source_file, 'r', 8192)
+        file_handle = open(local_source_file, 'rb', 8192)
         file_handle.seek(0, os.SEEK_END)
         size = file_handle.tell()
         file_handle.seek(0)


### PR DESCRIPTION
Fix for https://github.com/PVince81/pyocclient/issues/57

@mildagenius can you run the unit tests `./runtests.sh` on Windows ?
Please make sure to edit the config file first `owncloud/test/config.py` and create a user called "share".
