### PR TITLE
[WIP][don't merge yet] Python 3.4 compatibility

### DIFF
--- a/owncloud/__init__.py
+++ b/owncloud/__init__.py
@@ -2,5 +2,5 @@
 #
 # vim: expandtab shiftwidth=4 softtabstop=4
 #
-from owncloud import *
+from .owncloud import *
 

--- a/owncloud/owncloud.py
+++ b/owncloud/owncloud.py
@@ -8,13 +8,14 @@ Makes it possible to access files on a remote ownCloud instance,
 share them or access application attributes.
 """
 
+from __future__ import division
 import datetime
 import time
-import urllib
-import urlparse
 import requests
 import xml.etree.ElementTree as ET
 import os
+import six
+from six.moves import urllib
 
 class ResponseError(Exception):
     def __init__(self, res):
@@ -64,33 +65,33 @@ class FileInfo():
 
     def get_name(self):
         """Returns the base name of the file (without path)
-        
+
         :returns: name of the file
         """
         return self.name
 
     def get_size(self):
         """Returns the size of the file
-        
+
         :returns: size of the file
         """
-        if (self.attributes.has_key('{DAV:}getcontentlength')):
+        if '{DAV:}getcontentlength' in self.attributes:
             return int(self.attributes['{DAV:}getcontentlength'])
         return None
 
     def get_etag(self):
         """Returns the file etag
-        
+
         :returns: file etag
         """
         return self.attributes['{DAV:}getetag']
 
     def get_content_type(self):
         """Returns the file content type
-        
+
         :returns: file content type
         """
-        if self.attributes.has_key('{DAV:}getcontenttype'):
+        if '{DAV:}getcontenttype' in self.attributes:
             return self.attributes['{DAV:}getcontenttype']
 
         if self.is_dir():
@@ -100,7 +101,7 @@ class FileInfo():
 
     def get_last_modified(self):
         """Returns the last modified time
-        
+
         :returns: last modified time
         :rtype: datetime object
         """
@@ -159,7 +160,7 @@ class Client():
         self.__verify_certs = kwargs.get('verify_certs', True)
         self.__single_session = kwargs.get('single_session', True)
 
-        url_components = urlparse.urlparse(url)
+        url_components = urllib.parse.urlparse(url)
         self.__davpath = url_components.path + 'remote.php/webdav'
         self.__webdav_url = url + 'remote.php/webdav'
 
@@ -198,8 +199,8 @@ class Client():
 
     def file_info(self, path):
         """Returns the file info for the given remote file
-        
-        :param path: path to the remote file 
+
+        :param path: path to the remote file
         :returns: file info
         :rtype: :class:`FileInfo` object or `None` if file
             was not found
@@ -212,8 +213,8 @@ class Client():
 
     def list(self, path):
         """Returns the listing/contents of the given remote directory
-        
-        :param path: path to the remote directory 
+
+        :param path: path to the remote directory
         :returns: directory listing
         :rtype: array of :class:`FileInfo` objects
         :raises: ResponseError in case an HTTP error status was returned
@@ -260,7 +261,7 @@ class Client():
                 # local_file = res.headers['content-disposition']
                 local_file = os.path.basename(remote_path)
 
-            file_handle = open(local_file, 'w', 8192)
+            file_handle = open(local_file, 'wb', 8192)
             for chunk in res.iter_content(8192):
                 file_handle.write(chunk)
             file_handle.close()
@@ -277,7 +278,7 @@ class Client():
         """
         remote_path = self.__normalize_path(remote_path)
         url = self.url + 'index.php/apps/files/ajax/download.php?dir=' \
-            + urllib.quote(remote_path)
+            + urllib.parse.quote(remote_path)
         res = self.__session.get(
                 url,
                 stream = True
@@ -288,7 +289,7 @@ class Client():
                 # targetFile = res.headers['content-disposition']
                 local_file = os.path.basename(remote_path)
 
-            file_handle = open(local_file, 'w', 8192)
+            file_handle = open(local_file, 'wb', 8192)
             for chunk in res.iter_content(8192):
                 file_handle.write(chunk)
             file_handle.close()
@@ -333,7 +334,7 @@ class Client():
 
         if remote_path[-1] == '/':
             remote_path += os.path.basename(local_source_file)
-        file_handle = open(local_source_file, 'r', 8192)
+        file_handle = open(local_source_file, 'rb', 8192)
         res = self.__make_dav_request(
                 'PUT',
                 remote_path,
@@ -399,7 +400,7 @@ class Client():
 
         stat_result = os.stat(local_source_file)
 
-        file_handle = open(local_source_file, 'r', 8192)
+        file_handle = open(local_source_file, 'rb', 8192)
         file_handle.seek(0, os.SEEK_END)
         size = file_handle.tell()
         file_handle.seek(0)
@@ -416,14 +417,14 @@ class Client():
                     headers = headers
                     )
 
-        chunk_count = size / chunk_size
+        chunk_count = size // chunk_size
 
         if size % chunk_size > 0:
             chunk_count += 1
 
         if chunk_count > 1:
             headers['OC-CHUNKED'] = 1
-       
+
         for chunk_index in range(0, chunk_count):
             data = file_handle.read(chunk_size)
             if chunk_count > 1:
@@ -506,7 +507,7 @@ class Client():
         data = {}
         if perms:
             data['permissions'] = perms
-        if isinstance(password, basestring):
+        if isinstance(password, six.string_types):
             data['password'] = password
         if ((public_upload is not None) and (isinstance(public_upload, bool))):
             data['publicUpload'] = str(public_upload).lower()
@@ -527,7 +528,7 @@ class Client():
         :param remote_path_source: source file or folder to move
         :param remote_path_target: target file to which to move
         the source file. A target directory can also be specified
-        instead by appending a "/" 
+        instead by appending a "/"
         :returns: True if the operation succeeded, False otherwise
         :raises: ResponseError in case an HTTP error status was returned
         """
@@ -536,7 +537,7 @@ class Client():
 
         remote_path_source = self.__normalize_path(remote_path_source)
         headers = {
-            'Destination': self.__webdav_url + urllib.quote(self.__encode_string(remote_path_target))
+            'Destination': self.__webdav_url + urllib.parse.quote(self.__encode_string(remote_path_target))
         }
 
         return self.__make_dav_request(
@@ -607,7 +608,7 @@ class Client():
         :returns: array of shares or empty array if the operation failed
         :raises: ResponseError in case an HTTP error status was returned
         """
-        if not (isinstance(path, basestring)):
+        if not (isinstance(path, six.string_types)):
             return None
 
         data = 'shares'
@@ -621,7 +622,7 @@ class Client():
             subfiles = kwargs.get('subfiles', False)
             if (isinstance(subfiles, bool) and subfiles):
                 args['subfiles'] = subfiles
-            data += urllib.urlencode(args)
+            data += urllib.parse.urlencode(args)
 
         res = self.__make_ocs_request(
                 'GET',
@@ -657,7 +658,7 @@ class Client():
         """
         perms = kwargs.get('perms', self.OCS_PERMISSION_READ)
         if (((not isinstance(perms, int)) or (perms > self.OCS_PERMISSION_ALL))
-            or ((not isinstance(user, basestring)) or (user == ''))):
+            or ((not isinstance(user, six.string_types)) or (user == ''))):
             return False
 
         path = self.__normalize_path(path)
@@ -725,9 +726,9 @@ class Client():
         """
         path = 'getattribute'
         if app is not None:
-            path += '/' + urllib.quote(app, '')
+            path += '/' + urllib.parse.quote(app, '')
             if key is not None:
-                path += '/' + urllib.quote(self.__encode_string(key), '')
+                path += '/' + urllib.parse.quote(self.__encode_string(key), '')
         res = self.__make_ocs_request(
                 'GET',
                 self.OCS_SERVICE_PRIVATEDATA,
@@ -763,7 +764,7 @@ class Client():
         :returns: True if the operation succeeded, False otherwise
         :raises: ResponseError in case an HTTP error status was returned
         """
-        path = 'setattribute/' + urllib.quote(app, '') + '/' + urllib.quote(self.__encode_string(key), '')
+        path = 'setattribute/' + urllib.parse.quote(app, '') + '/' + urllib.parse.quote(self.__encode_string(key), '')
         res = self.__make_ocs_request(
                 'POST',
                 self.OCS_SERVICE_PRIVATEDATA,
@@ -784,7 +785,7 @@ class Client():
         :returns: True if the operation succeeded, False otherwise
         :raises: ResponseError in case an HTTP error status was returned
         """
-        path = 'deleteattribute/' + urllib.quote(app, '') + '/' + urllib.quote(self.__encode_string(key), '')
+        path = 'deleteattribute/' + urllib.parse.quote(app, '') + '/' + urllib.parse.quote(self.__encode_string(key), '')
         res = self.__make_ocs_request(
                 'POST',
                 self.OCS_SERVICE_PRIVATEDATA,
@@ -816,7 +817,7 @@ class Client():
         :param s: str or unicode to encode
         :returns: encoded output as str
         """
-        if isinstance(s, unicode):
+        if isinstance(s, six.text_type):
             return s.encode('utf-8')
         return s
 
@@ -848,7 +849,7 @@ class Client():
 
         attributes = kwargs.copy()
 
-        if not attributes.has_key('headers'):
+        if not 'headers' in attributes:
             attributes['headers'] = {}
 
         attributes['headers']['OCS-APIREQUEST'] = 'true'
@@ -874,7 +875,7 @@ class Client():
         path = self.__normalize_path(path)
         res = self.__session.request(
             method,
-            self.__webdav_url + urllib.quote(self.__encode_string(path)),
+            self.__webdav_url + urllib.parse.quote(self.__encode_string(path)),
             **kwargs
         )
         if self.__debug:
@@ -906,9 +907,12 @@ class Client():
         :param el: ElementTree element containing a single DAV response
         :returns :class:`FileInfo`
         """
-        href = urllib.unquote(
-                self.__strip_dav_path(dav_response.find('{DAV:}href').text)
-                ).decode('utf-8')
+        href = urllib.parse.unquote(
+                self.__strip_dav_path(dav_response.find('{DAV:}href').text
+                    ))
+        if isinstance(href, six.binary_type):
+            href = href.decode('utf-8')
+
         file_type = 'file'
         if href[-1] == '/':
             file_type = 'dir'

--- a/owncloud/test/test.py
+++ b/owncloud/test/test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: expandtab shiftwidth=4 softtabstop=4
 #
+from __future__ import division
 import unittest
 from unittest_data_provider import data_provider
 import os
@@ -9,6 +10,7 @@ import owncloud
 import datetime
 import time
 import tempfile
+import six
 
 from config import Config
 
@@ -47,12 +49,13 @@ class TestFileAccess(unittest.TestCase):
 
     @staticmethod
     def __create_file(target_file, size):
-        file_handle = open(target_file, 'w')
+        file_handle = open(target_file, 'wb')
         dummy_data = ''
         for i in range(0, 1024):
             dummy_data += 'X'
+        dummy_data = six.b(dummy_data)
 
-        for i in range(0, size / 1024):
+        for i in range(0, size // 1024):
             # write in 1kb blocks
             file_handle.write(dummy_data)
         file_handle.close()

--- a/owncloud/test/test.py
+++ b/owncloud/test/test.py
@@ -74,7 +74,7 @@ class TestFileAccess(unittest.TestCase):
         """Test reading remote file"""
         self.assertTrue(self.client.mkdir(self.test_root + subdir))
         self.assertTrue(self.client.put_file_contents(self.test_root + subdir + '/' + file_name, content))
-        self.assertEquals(self.client.get_file_contents(self.test_root + subdir + '/' + file_name), content)
+        self.assertEqual(self.client.get_file_contents(self.test_root + subdir + '/' + file_name), content)
 
     @data_provider(files_content)
     def test_get_file_info(self, file_name, content, subdir):
@@ -84,19 +84,19 @@ class TestFileAccess(unittest.TestCase):
 
         file_info = self.client.file_info(self.test_root + file_name)
         self.assertTrue(isinstance(file_info, owncloud.FileInfo))
-        self.assertEquals(file_info.get_name(), file_name)
-        self.assertEquals(file_info.get_size(), len(content))
+        self.assertEqual(file_info.get_name(), file_name)
+        self.assertEqual(file_info.get_size(), len(content))
         self.assertIsNotNone(file_info.get_etag())
-        self.assertEquals(file_info.get_content_type(), 'text/plain')
+        self.assertEqual(file_info.get_content_type(), 'text/plain')
         self.assertTrue(type(file_info.get_last_modified()) is datetime.datetime)
         self.assertFalse(file_info.is_dir())
 
         dir_info = self.client.file_info(self.test_root + subdir)
         self.assertTrue(isinstance(dir_info, owncloud.FileInfo))
-        self.assertEquals(dir_info.get_name(), subdir)
+        self.assertEqual(dir_info.get_name(), subdir)
         self.assertIsNone(dir_info.get_size())
         self.assertIsNotNone(dir_info.get_etag())
-        self.assertEquals(dir_info.get_content_type(), 'httpd/unix-directory')
+        self.assertEqual(dir_info.get_content_type(), 'httpd/unix-directory')
         self.assertTrue(type(dir_info.get_last_modified()) is datetime.datetime)
         self.assertTrue(dir_info.is_dir())
 
@@ -104,7 +104,7 @@ class TestFileAccess(unittest.TestCase):
         """Test getting file info for non existing file"""
         with self.assertRaises(owncloud.ResponseError) as e:
             self.client.file_info(self.test_root + 'unexist')
-        self.assertEquals(e.exception.status_code, 404)
+        self.assertEqual(e.exception.status_code, 404)
 
     def test_get_file_listing(self):
         """Test getting file listing"""
@@ -116,12 +116,12 @@ class TestFileAccess(unittest.TestCase):
         self.assertTrue(self.client.put_file_contents(self.test_root + 'subdir/in dir.txt', ''))
 
         listing = self.client.list(self.test_root)
-        self.assertEquals(len(listing), 5)
-        self.assertEquals(listing[0].get_name(), 'abc.txt')
-        self.assertEquals(listing[1].get_name(), 'file one.txt')
-        self.assertEquals(listing[2].get_name(), 'subdir')
-        self.assertEquals(listing[3].get_name(), 'zz+z.txt')
-        self.assertEquals(listing[4].get_name(), u'中文.txt')
+        self.assertEqual(len(listing), 5)
+        self.assertEqual(listing[0].get_name(), 'abc.txt')
+        self.assertEqual(listing[1].get_name(), 'file one.txt')
+        self.assertEqual(listing[2].get_name(), 'subdir')
+        self.assertEqual(listing[3].get_name(), 'zz+z.txt')
+        self.assertEqual(listing[4].get_name(), u'中文.txt')
 
         self.assertTrue(listing[2].is_dir())
         self.assertFalse(listing[3].is_dir())
@@ -130,7 +130,7 @@ class TestFileAccess(unittest.TestCase):
         """Test getting file listing for non existing directory"""
         with self.assertRaises(owncloud.ResponseError) as e:
             self.client.list(self.test_root + 'unexist')
-        self.assertEquals(e.exception.status_code, 404)
+        self.assertEqual(e.exception.status_code, 404)
 
     @data_provider(files)
     def test_upload_small_file(self, file_name):
@@ -142,7 +142,7 @@ class TestFileAccess(unittest.TestCase):
 
         file_info = self.client.file_info(self.test_root + file_name)
         self.assertIsNotNone(file_info)
-        self.assertEquals(file_info.get_size(), 2 * 1024)
+        self.assertEqual(file_info.get_size(), 2 * 1024)
 
     def test_upload_two_chunks(self):
         """Test chunked upload with two chunks"""
@@ -154,7 +154,7 @@ class TestFileAccess(unittest.TestCase):
         file_info = self.client.file_info(self.test_root + 'chunk_test.dat')
 
         self.assertIsNotNone(file_info)
-        self.assertEquals(file_info.get_size(), 18 * 1024 * 1024)
+        self.assertEqual(file_info.get_size(), 18 * 1024 * 1024)
 
     @data_provider(files)
     def test_upload_big_file(self, file_name):
@@ -166,7 +166,7 @@ class TestFileAccess(unittest.TestCase):
 
         file_info = self.client.file_info(self.test_root + file_name)
         self.assertIsNotNone(file_info)
-        self.assertEquals(file_info.get_size(), 22 * 1024 * 1024)
+        self.assertEqual(file_info.get_size(), 22 * 1024 * 1024)
 
     def test_upload_timestamp(self):
         # TODO: test with keeping timestamp and not keeping it
@@ -200,14 +200,14 @@ class TestFileAccess(unittest.TestCase):
         temp_file = self.temp_dir + 'pyoctest.dat'
         self.assertTrue(self.client.mkdir(self.test_root + subdir))
         self.assertTrue(self.client.put_file_contents(self.test_root + subdir + '/' + file_name, content))
-       
+
         self.assertTrue(self.client.get_file(self.test_root + subdir + '/' + file_name, temp_file))
 
         f = open(temp_file, 'r')
         s = f.read()
         f.close()
         os.unlink(temp_file)
-        self.assertEquals(s, content)
+        self.assertEqual(s, content)
 
     def test_download_dir(self):
         import zipfile
@@ -224,8 +224,8 @@ class TestFileAccess(unittest.TestCase):
 
         zip_info = zipfile.ZipFile(temp_file)
         listing = zip_info.namelist()
-        
-        self.assertEquals(len(listing), 3)
+
+        self.assertEqual(len(listing), 3)
         os.unlink(temp_file)
 
     @data_provider(files_content)
@@ -236,7 +236,7 @@ class TestFileAccess(unittest.TestCase):
         self.assertTrue(self.client.delete(self.test_root + subdir + '/' + file_name))
         with self.assertRaises(owncloud.ResponseError) as e:
             self.client.file_info(self.test_root + subdir + '/' + file_name)
-        self.assertEquals(e.exception.status_code, 404)
+        self.assertEqual(e.exception.status_code, 404)
 
     @data_provider(files_content)
     def test_delete_dir(self, file_name, content, subdir):
@@ -246,10 +246,10 @@ class TestFileAccess(unittest.TestCase):
         self.assertTrue(self.client.delete(self.test_root + subdir))
         with self.assertRaises(owncloud.ResponseError) as e:
             self.client.file_info(self.test_root + subdir + '/' + file_name)
-        self.assertEquals(e.exception.status_code, 404)
+        self.assertEqual(e.exception.status_code, 404)
         with self.assertRaises(owncloud.ResponseError) as e:
             self.client.file_info(self.test_root + subdir)
-        self.assertEquals(e.exception.status_code, 404)
+        self.assertEqual(e.exception.status_code, 404)
 
     def test_move_rename_in_place(self):
         """Test rename in place"""
@@ -266,7 +266,7 @@ class TestFileAccess(unittest.TestCase):
                 self.test_root + 'renamed in place.txt'
             )
         )
-        self.assertEquals(
+        self.assertEqual(
             self.client.get_file_contents(
                 self.test_root + 'renamed in place.txt'
             ),
@@ -293,7 +293,7 @@ class TestFileAccess(unittest.TestCase):
                 self.test_root + 'subdir/file renamed.txt'
             )
         )
-        self.assertEquals(
+        self.assertEqual(
             self.client.get_file_contents(
                 self.test_root + 'subdir/file renamed.txt'
             ),
@@ -321,7 +321,7 @@ class TestFileAccess(unittest.TestCase):
                 self.test_root + 'subdir/'
             )
         )
-        self.assertEquals(
+        self.assertEqual(
             self.client.get_file_contents(
                 self.test_root + 'subdir/movetodir.txt'
             ),
@@ -371,7 +371,7 @@ class TestFileAccess(unittest.TestCase):
                 self.test_root + u'更多中文.txt'
             )
         )
-        self.assertEquals(
+        self.assertEqual(
             self.client.get_file_contents(
                 self.test_root + u'更多中文.txt'
             ),
@@ -397,7 +397,7 @@ class TestFileAccess(unittest.TestCase):
                 self.test_root + u'subdir/中文.txt'
             )
         )
-        self.assertEquals(
+        self.assertEqual(
             self.client.get_file_contents(
                 self.test_root + u'subdir/中文.txt'
             ),
@@ -418,9 +418,9 @@ class TestFileAccess(unittest.TestCase):
                 self.test_root + 'move not possible.txt',
                 self.test_root + 'non-existing-dir/subdir/x.txt'
             )
-        self.assertEquals(e.exception.status_code, 409)
+        self.assertEqual(e.exception.status_code, 409)
 
-        self.assertEquals(
+        self.assertEqual(
             self.client.get_file_contents(
                 self.test_root + 'move not possible.txt'
             ),
@@ -439,7 +439,7 @@ class TestFileAccess(unittest.TestCase):
         self.assertTrue(self.client.is_shared(path))
         self.assertTrue(isinstance(share_info, owncloud.PublicShare))
         self.assertTrue(type(share_info.share_id) is int)
-        self.assertEquals(share_info.target_file, path)
+        self.assertEqual(share_info.target_file, path)
         self.assertTrue(type(share_info.link) is str)
         self.assertTrue(type(share_info.token) is str)
 
@@ -447,7 +447,7 @@ class TestFileAccess(unittest.TestCase):
         """Test sharing a file with link"""
         with self.assertRaises(owncloud.ResponseError) as e:
             self.client.share_file_with_link(self.test_root + 'unexist.txt')
-        self.assertEquals(e.exception.status_code, 404)
+        self.assertEqual(e.exception.status_code, 404)
 
     @data_provider(files)
     def test_share_with_user(self, file_name):
@@ -460,7 +460,7 @@ class TestFileAccess(unittest.TestCase):
 
         self.assertTrue(self.client.is_shared(path))
         self.assertTrue(isinstance(share_info, owncloud.UserShare))
-        self.assertEquals(share_info.share, path)
+        self.assertEqual(share_info.share, path)
         self.assertTrue(type(share_info.share_id) is int)
         self.assertTrue(share_info.perms, 31)
         self.assertTrue(self.client.delete(path))
@@ -482,7 +482,7 @@ class TestFileAccess(unittest.TestCase):
         """Test is_shared - path does not exist"""
         with self.assertRaises(owncloud.ResponseError) as e:
             self.client.is_shared(self.test_root + 'does_not_exist')
-        self.assertEquals(e.exception.status_code, 404)
+        self.assertEqual(e.exception.status_code, 404)
 
     def test_is_shared_not_shared_path(self):
         """Test is_shared - path does exist, but it's not shared yet"""
@@ -504,7 +504,7 @@ class TestFileAccess(unittest.TestCase):
         """Test get_shares - path does not exist"""
         with self.assertRaises(owncloud.ResponseError) as e:
             self.client.get_shares(self.test_root + 'does_not_exist')
-        self.assertEquals(e.exception.status_code, 404)
+        self.assertEqual(e.exception.status_code, 404)
 
     @data_provider(files)
     def test_get_shares(self, file_name):
@@ -520,7 +520,7 @@ class TestFileAccess(unittest.TestCase):
         with self.assertRaises(owncloud.ResponseError) as e:
             shares = self.client.get_shares(self.test_root + file_name, subfiles=True)
         self.assertIsNone(shares)
-        self.assertEquals(e.exception.status_code, 400)
+        self.assertEqual(e.exception.status_code, 400)
 
         shares = self.client.get_shares(self.test_root, reshares=True, subfiles=True)
         self.assertIsNotNone(shares)
@@ -627,8 +627,8 @@ class TestPrivateDataAccess(unittest.TestCase):
         """Test getting an attribute"""
         self.assertTrue(self.client.set_attribute(self.app_name, attr1, value1))
 
-        self.assertEquals(self.client.get_attribute(self.app_name, attr1), value1)
-        self.assertEquals(self.client.get_attribute(self.app_name), [(attr1, value1)])
+        self.assertEqual(self.client.get_attribute(self.app_name, attr1), value1)
+        self.assertEqual(self.client.get_attribute(self.app_name), [(attr1, value1)])
         self.assertTrue(self.client.delete_attribute(self.app_name, attr1))
 
     def test_get_non_existing_attribute(self):
@@ -639,20 +639,20 @@ class TestPrivateDataAccess(unittest.TestCase):
     def test_set_attribute_empty(self, attr1, value1):
         """Test setting an attribute to an empty value"""
         self.assertTrue(self.client.set_attribute(self.app_name, attr1, ''))
-        self.assertEquals(self.client.get_attribute(self.app_name, attr1), '')
-        self.assertEquals(self.client.get_attribute(self.app_name), [(attr1, '')])
+        self.assertEqual(self.client.get_attribute(self.app_name, attr1), '')
+        self.assertEqual(self.client.get_attribute(self.app_name), [(attr1, '')])
         self.assertTrue(self.client.delete_attribute(self.app_name, attr1))
 
     @data_provider(attrs)
     def test_delete_attribute(self, attr1, value1):
         """Test deleting an attribute"""
         self.assertTrue(self.client.set_attribute(self.app_name, attr1, value1))
-        self.assertEquals(self.client.get_attribute(self.app_name, attr1), value1)
+        self.assertEqual(self.client.get_attribute(self.app_name, attr1), value1)
 
         self.assertTrue(self.client.delete_attribute(self.app_name, attr1))
 
         self.assertIsNone(self.client.get_attribute(self.app_name, attr1))
-        self.assertEquals(self.client.get_attribute(self.app_name), [])
+        self.assertEqual(self.client.get_attribute(self.app_name), [])
 
 class TestGetConfig(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
There is something left to do that I was not able to track down yet. I think i was close once, but missed the time to crunch on this :( A goal of course is to continue to support Python 2.7. The test against 2.7 run fine for me.

On 3.4 a test run reveals this:

```
# ./runtests.sh 
....Assertion error caught with data set  ['文件.txt', b'\xe4\xbd\xa0\xe5\xa5\xbd\xe4\xb8\x96\xe7\x95\x8c', '文件夹']
FAssertion error caught with data set  ['test.txt', 'Hello world!', 'subdir']
F..........FF.FFF.F...F....E/usr/lib/python3.4/unittest/case.py:605: ResourceWarning: unclosed <socket.socket fd=4, family=AddressFamily.AF_INET, type=SocketType.SOCK_STREAM, proto=6, laddr=('10.0.3.87', 56189), raddr=('10.0.3.1', 80)>
  outcome.errors.clear()
/usr/lib/python3.4/unittest/case.py:605: ResourceWarning: unclosed file <_io.BufferedReader name='/tmp/pyocclient_test1418208618/pyoctest.dat'>
  outcome.errors.clear()
E/usr/lib/python3.4/unittest/case.py:605: ResourceWarning: unclosed <socket.socket fd=4, family=AddressFamily.AF_INET, type=SocketType.SOCK_STREAM, proto=6, laddr=('10.0.3.87', 56193), raddr=('10.0.3.1', 80)>
  outcome.errors.clear()
/usr/lib/python3.4/unittest/case.py:605: ResourceWarning: unclosed file <_io.BufferedReader name='/tmp/pyocclient_test1418208619/pyoctest.dir//file2.dat'>
  outcome.errors.clear()
E/usr/lib/python3.4/unittest/case.py:605: ResourceWarning: unclosed <socket.socket fd=4, family=AddressFamily.AF_INET, type=SocketType.SOCK_STREAM, proto=6, laddr=('10.0.3.87', 56196), raddr=('10.0.3.1', 80)>
  outcome.errors.clear()
/usr/lib/python3.4/unittest/case.py:605: ResourceWarning: unclosed file <_io.BufferedReader name='/tmp/pyocclient_test1418208620/pyoctest.dat'>
  outcome.errors.clear()
.E/usr/lib/python3.4/unittest/case.py:605: ResourceWarning: unclosed <socket.socket fd=4, family=AddressFamily.AF_INET, type=SocketType.SOCK_STREAM, proto=6, laddr=('10.0.3.87', 56202), raddr=('10.0.3.1', 80)>
  outcome.errors.clear()
/usr/lib/python3.4/unittest/case.py:605: ResourceWarning: unclosed file <_io.BufferedReader name='/tmp/pyocclient_test1418208622/pyoctest.dat'>
  outcome.errors.clear()
......
======================================================================
ERROR: test_upload_big_file (__main__.TestFileAccess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.4/dist-packages/unittest_data_provider/__init__.py", line 7, in repl
    fn(self, *i)
  File "owncloud/test/test.py", line 167, in test_upload_big_file
    self.assertTrue(self.client.put_file(self.test_root + file_name, temp_file))
  File "/root/pyocclient/owncloud/owncloud.py", line 326, in put_file
    **kwargs
  File "/root/pyocclient/owncloud/owncloud.py", line 440, in __put_file_chunked
    headers = headers
  File "/root/pyocclient/owncloud/owncloud.py", line 879, in __make_dav_request
    **kwargs
  File "/usr/local/lib/python3.4/dist-packages/requests/sessions.py", line 457, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python3.4/dist-packages/requests/sessions.py", line 569, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python3.4/dist-packages/requests/adapters.py", line 362, in send
    timeout=timeout
  File "/usr/local/lib/python3.4/dist-packages/requests/packages/urllib3/connectionpool.py", line 516, in urlopen
    body=body, headers=headers)
  File "/usr/local/lib/python3.4/dist-packages/requests/packages/urllib3/connectionpool.py", line 308, in _make_request
    conn.request(method, url, **httplib_request_kw)
  File "/usr/lib/python3.4/http/client.py", line 1090, in request
    self._send_request(method, url, body, headers)
  File "/usr/lib/python3.4/http/client.py", line 1123, in _send_request
    self.putheader(hdr, value)
  File "/usr/lib/python3.4/http/client.py", line 1069, in putheader
    value = b'\r\n\t'.join(values)
TypeError: sequence item 0: expected bytes, bytearray, or an object with the buffer interface, float found

======================================================================
ERROR: test_upload_directory (__main__.TestFileAccess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "owncloud/test/test.py", line 191, in test_upload_directory
    self.assertTrue(self.client.put_directory(self.test_root + 'subdir', temp_dir))
  File "/root/pyocclient/owncloud/owncloud.py", line 377, in put_directory
    **kwargs
  File "/root/pyocclient/owncloud/owncloud.py", line 326, in put_file
    **kwargs
  File "/root/pyocclient/owncloud/owncloud.py", line 440, in __put_file_chunked
    headers = headers
  File "/root/pyocclient/owncloud/owncloud.py", line 879, in __make_dav_request
    **kwargs
  File "/usr/local/lib/python3.4/dist-packages/requests/sessions.py", line 457, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python3.4/dist-packages/requests/sessions.py", line 569, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python3.4/dist-packages/requests/adapters.py", line 362, in send
    timeout=timeout
  File "/usr/local/lib/python3.4/dist-packages/requests/packages/urllib3/connectionpool.py", line 516, in urlopen
    body=body, headers=headers)
  File "/usr/local/lib/python3.4/dist-packages/requests/packages/urllib3/connectionpool.py", line 308, in _make_request
    conn.request(method, url, **httplib_request_kw)
  File "/usr/lib/python3.4/http/client.py", line 1090, in request
    self._send_request(method, url, body, headers)
  File "/usr/lib/python3.4/http/client.py", line 1123, in _send_request
    self.putheader(hdr, value)
  File "/usr/lib/python3.4/http/client.py", line 1069, in putheader
    value = b'\r\n\t'.join(values)
TypeError: sequence item 0: expected bytes, bytearray, or an object with the buffer interface, float found

======================================================================
ERROR: test_upload_small_file (__main__.TestFileAccess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.4/dist-packages/unittest_data_provider/__init__.py", line 7, in repl
    fn(self, *i)
  File "owncloud/test/test.py", line 143, in test_upload_small_file
    self.assertTrue(self.client.put_file(self.test_root + file_name, temp_file))
  File "/root/pyocclient/owncloud/owncloud.py", line 326, in put_file
    **kwargs
  File "/root/pyocclient/owncloud/owncloud.py", line 440, in __put_file_chunked
    headers = headers
  File "/root/pyocclient/owncloud/owncloud.py", line 879, in __make_dav_request
    **kwargs
  File "/usr/local/lib/python3.4/dist-packages/requests/sessions.py", line 457, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python3.4/dist-packages/requests/sessions.py", line 569, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python3.4/dist-packages/requests/adapters.py", line 362, in send
    timeout=timeout
  File "/usr/local/lib/python3.4/dist-packages/requests/packages/urllib3/connectionpool.py", line 516, in urlopen
    body=body, headers=headers)
  File "/usr/local/lib/python3.4/dist-packages/requests/packages/urllib3/connectionpool.py", line 308, in _make_request
    conn.request(method, url, **httplib_request_kw)
  File "/usr/lib/python3.4/http/client.py", line 1090, in request
    self._send_request(method, url, body, headers)
  File "/usr/lib/python3.4/http/client.py", line 1123, in _send_request
    self.putheader(hdr, value)
  File "/usr/lib/python3.4/http/client.py", line 1069, in putheader
    value = b'\r\n\t'.join(values)
TypeError: sequence item 0: expected bytes, bytearray, or an object with the buffer interface, float found

======================================================================
ERROR: test_upload_two_chunks (__main__.TestFileAccess)
Test chunked upload with two chunks
----------------------------------------------------------------------
Traceback (most recent call last):
  File "owncloud/test/test.py", line 154, in test_upload_two_chunks
    self.assertTrue(self.client.put_file(self.test_root + 'chunk_test.dat', temp_file))
  File "/root/pyocclient/owncloud/owncloud.py", line 326, in put_file
    **kwargs
  File "/root/pyocclient/owncloud/owncloud.py", line 440, in __put_file_chunked
    headers = headers
  File "/root/pyocclient/owncloud/owncloud.py", line 879, in __make_dav_request
    **kwargs
  File "/usr/local/lib/python3.4/dist-packages/requests/sessions.py", line 457, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python3.4/dist-packages/requests/sessions.py", line 569, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python3.4/dist-packages/requests/adapters.py", line 362, in send
    timeout=timeout
  File "/usr/local/lib/python3.4/dist-packages/requests/packages/urllib3/connectionpool.py", line 516, in urlopen
    body=body, headers=headers)
  File "/usr/local/lib/python3.4/dist-packages/requests/packages/urllib3/connectionpool.py", line 308, in _make_request
    conn.request(method, url, **httplib_request_kw)
  File "/usr/lib/python3.4/http/client.py", line 1090, in request
    self._send_request(method, url, body, headers)
  File "/usr/lib/python3.4/http/client.py", line 1123, in _send_request
    self.putheader(hdr, value)
  File "/usr/lib/python3.4/http/client.py", line 1069, in putheader
    value = b'\r\n\t'.join(values)
TypeError: sequence item 0: expected bytes, bytearray, or an object with the buffer interface, float found

======================================================================
FAIL: test_download_file (__main__.TestFileAccess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.4/dist-packages/unittest_data_provider/__init__.py", line 7, in repl
    fn(self, *i)
  File "owncloud/test/test.py", line 213, in test_download_file
    self.assertEqual(s, content)
AssertionError: '你好世界' != b'\xe4\xbd\xa0\xe5\xa5\xbd\xe4\xb8\x96\xe7\x95\x8c'

======================================================================
FAIL: test_get_file_contents (__main__.TestFileAccess)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.4/dist-packages/unittest_data_provider/__init__.py", line 7, in repl
    fn(self, *i)
  File "owncloud/test/test.py", line 80, in test_get_file_contents
    self.assertEqual(self.client.get_file_contents(self.test_root + subdir + '/' + file_name), content)
AssertionError: b'Hello world!' != 'Hello world!'

======================================================================
FAIL: test_move_and_rename (__main__.TestFileAccess)
Test rename into subdir
----------------------------------------------------------------------
Traceback (most recent call last):
  File "owncloud/test/test.py", line 303, in test_move_and_rename
    'first file'
AssertionError: b'first file' != 'first file'

======================================================================
FAIL: test_move_rename_in_place (__main__.TestFileAccess)
Test rename in place
----------------------------------------------------------------------
Traceback (most recent call last):
  File "owncloud/test/test.py", line 276, in test_move_rename_in_place
    'to rename'
AssertionError: b'to rename' != 'to rename'

======================================================================
FAIL: test_move_to_dir (__main__.TestFileAccess)
Test move into directory
----------------------------------------------------------------------
Traceback (most recent call last):
  File "owncloud/test/test.py", line 331, in test_move_to_dir
    'z file'
AssertionError: b'z file' != 'z file'

======================================================================
FAIL: test_move_to_non_existing_dir (__main__.TestFileAccess)
Test error when moving to non existing dir
----------------------------------------------------------------------
Traceback (most recent call last):
  File "owncloud/test/test.py", line 430, in test_move_to_non_existing_dir
    'x'
AssertionError: b'x' != 'x'

======================================================================
FAIL: test_move_unicode (__main__.TestFileAccess)
Test move unicode to dir
----------------------------------------------------------------------
Traceback (most recent call last):
  File "owncloud/test/test.py", line 407, in test_move_unicode
    '2'
AssertionError: b'2' != '2'

======================================================================
FAIL: test_rename_unicode (__main__.TestFileAccess)
Test rename unicode
----------------------------------------------------------------------
Traceback (most recent call last):
  File "owncloud/test/test.py", line 381, in test_rename_unicode
    '1'
AssertionError: b'1' != '1'

======================================================================
FAIL: test_update_share_password (__main__.TestFileAccess)
Test updating a share parameters - password
----------------------------------------------------------------------
Traceback (most recent call last):
  File "owncloud/test/test.py", line 601, in test_update_share_password
    self.assertTrue('share_with_displayname' in share_info)
AssertionError: False is not true

----------------------------------------------------------------------
Ran 43 tests in 76.586s

FAILED (failures=9, errors=4)

```