### PR TITLE
Don't check for password format, just existence

### DIFF
--- a/owncloud/test/test.py
+++ b/owncloud/test/test.py
@@ -596,7 +596,7 @@ class TestFileAccess(unittest.TestCase):
         self.assertTrue(self.client.update_share(share_id, password="2hard2guess"))
         share_info = self.client.get_shares(path)[0]
         self.assertTrue('share_with_displayname' in share_info)
-        self.assertTrue(share_info['share_with_displayname'].startswith("$2"))
+        self.assertIsNotNone(share_info['share_with_displayname'])
         self.assertTrue(self.client.delete_share(share_id))
 
 


### PR DESCRIPTION
@soalhn this is because on OC master the password hash format has change, so now we just check whether it exists.
