### PR TITLE
Clear cookies when single_session is None

### DIFF
--- a/owncloud/test/config.py
+++ b/owncloud/test/config.py
@@ -19,7 +19,7 @@ Config = {
     'test_root': 'pyoctestroot%s' % test_id,
     # app name to use when testing privatedata API
     'app_name': 'pyocclient_test%s' % test_id,
-    # single session mode (only set to False for ownCloud 5)
+    # single session mode (only set to False for ownCloud 5 or ownCloud 6 with encryption enabled)
     'single_session': True
 }
 


### PR DESCRIPTION
This is to make sure ownCloud will not reuse an existing bogus session

Fixes https://github.com/owncloud/pyocclient/issues/106, but requires single_session to be False in OC 6 with encryption.