### PR TITLE
"groups?search" can return multiple elements

### DIFF
--- a/owncloud/owncloud.py
+++ b/owncloud/owncloud.py
@@ -1112,12 +1112,12 @@ class Client():
 
         if res.status_code == 200:
             tree = ET.fromstring(res.text)
-            code_el = tree.find('data/groups/element')
 
-            if code_el is not None and code_el.text == group_name:
-                return True
-            else:
-                return False
+            for code_el in tree.findall('data/groups/element'):
+                if code_el is not None and code_el.text == group_name:
+                    return True
+
+            return False
 
         raise ResponseError(res)
 


### PR DESCRIPTION
in "group_exists" only the first element was checked. so if you would have this groups:
group1,group2,group and search for "group" you might get return "False" because "group1" was returned as the first element and that is not equal "group"