### PR TITLE
Allow get_share without arguments

### DIFF
--- a/owncloud/owncloud.py
+++ b/owncloud/owncloud.py
@@ -534,8 +534,7 @@ class Client():
                     value = child.text
                     share_attr[key] = value
                 shares.append(share_attr)
-            if len(shares) > 0:
-                return shares
+            return shares
         raise HTTPResponseError(res)
 
     def accept_remote_share(self, share_id):

--- a/owncloud/owncloud.py
+++ b/owncloud/owncloud.py
@@ -769,8 +769,7 @@ class Client():
                     value = child.text
                     share_attr[key] = value
                 shares.append(share_attr)
-            if len(shares) > 0:
-                return shares
+            return shares
         raise HTTPResponseError(res)
 
     def create_user(self, user_name, initial_password):

--- a/owncloud/test/test.py
+++ b/owncloud/test/test.py
@@ -666,6 +666,21 @@ class TestFileAccess(unittest.TestCase):
         self.assertIsInstance(shares, list)
         self.assertGreater(len(shares), 1)
 
+    def test_get_shares_empty(self):
+        """Test get shares with empty result"""
+        file_name = 'test.txt'
+        self.assertTrue(self.client.put_file_contents(self.test_root + file_name, 'hello world!'))
+
+        # Get all shares
+        shares = self.client.get_shares()
+        self.assertEquals(shares, [])
+
+        shares = None
+        with self.assertRaises(owncloud.ResponseError) as e:
+            shares = self.client.get_shares(self.test_root + file_name)
+        self.assertIsNone(shares)
+        self.assertEquals(e.exception.status_code, 404)
+
     def test_update_share_wo_params(self):
         self.assertFalse(self.client.update_share(0))
 


### PR DESCRIPTION
@jvillafanez please review

Fixes https://github.com/owncloud/pyocclient/issues/131