### PR TITLE
Fix assertTrues that are supposed to be assertEquals

### DIFF
--- a/owncloud/test/test.py
+++ b/owncloud/test/test.py
@@ -601,7 +601,7 @@ class TestFileAccess(unittest.TestCase):
         self.assertTrue(isinstance(share_info, owncloud.ShareInfo))
         self.assertEquals(share_info.get_path(), path)
         self.assertTrue(type(share_info.get_id()) is int)
-        self.assertTrue(share_info.get_permissions(), '31')
+        self.assertEquals(share_info.get_permissions(), '31')
         self.assertTrue(self.client.delete(path))
 
     @data_provider(files)
@@ -617,7 +617,7 @@ class TestFileAccess(unittest.TestCase):
         self.assertTrue(isinstance(share_info, owncloud.ShareInfo))
         self.assertEquals(share_info.get_path(), path)
         self.assertTrue(type(share_info.get_id()) is int)
-        self.assertTrue(share_info.get_permissions(), 31)
+        self.assertEquals(share_info.get_permissions(), 31)
         self.assertTrue(self.client.delete(path))
 
     @data_provider(files)

--- a/owncloud/test/test.py
+++ b/owncloud/test/test.py
@@ -601,7 +601,7 @@ class TestFileAccess(unittest.TestCase):
         self.assertTrue(isinstance(share_info, owncloud.ShareInfo))
         self.assertEquals(share_info.get_path(), path)
         self.assertTrue(type(share_info.get_id()) is int)
-        self.assertEquals(share_info.get_permissions(), 31)
+        self.assertEquals(share_info.get_permissions(), 1)
         self.assertTrue(self.client.delete(path))
 
     @data_provider(files)

--- a/owncloud/test/test.py
+++ b/owncloud/test/test.py
@@ -601,7 +601,7 @@ class TestFileAccess(unittest.TestCase):
         self.assertTrue(isinstance(share_info, owncloud.ShareInfo))
         self.assertEquals(share_info.get_path(), path)
         self.assertTrue(type(share_info.get_id()) is int)
-        self.assertEquals(share_info.get_permissions(), '31')
+        self.assertEquals(share_info.get_permissions(), 31)
         self.assertTrue(self.client.delete(path))
 
     @data_provider(files)


### PR DESCRIPTION
Was reading over the tests while working on porting over them to py.test and these caught my eye.

Might as well fix them for the time being until my work is done with the py.test file