### PR TITLE
Improve docs, move contributors

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+docs/source/CONTRIBUTORS.rst

--- a/docs/source/CONTRIBUTORS.rst
+++ b/docs/source/CONTRIBUTORS.rst
@@ -1,0 +1,17 @@
+Contributors
+============
+
+* Vincent Petry <pvince81@owncloud.com>
+* Steffen Lindner <mail@steffen-lindner.de>
+* Soal <soal@soal.pl>
+* Bruno Santeramo <bruno.santeramo@gmail.com>
+* jennifer <jennifer@owncloud.com>
+* Sergio Bertolín <sbertolin@solidgear.es>
+* Alessandro Cosentino <cosenal@gmail.com>
+* Mike <mike@x220>
+* Joas Schilling <nickvergessen@owncloud.com>
+* Individual IT Services <info@individual-it.net>
+* Juan Pablo Villafáñez <jvillafanez@solidgear.es>
+* Simon Vigneux <svigneux@kronostechnologies.com>
+* Roeland Jago Douma <rullzer@owncloud.com>
+* Erik Pellikka <erik@pellikka.org>

--- a/docs/source/README.rst
+++ b/docs/source/README.rst
@@ -133,6 +133,7 @@ Then run the following commands:
 
 .. code-block:: bash
 
+    $ sphinx-apidoc -f -o docs/source owncloud/ owncloud/test
     $ cd docs
     $ make html
 
@@ -141,8 +142,4 @@ You can then find the documentation inside of "doc/build/html".
 Authors
 =======
 
-- Vincent Petry (@pvince81)
-- Steffen Lindner (@gomezr)
-- Soal (@soalhn)
-- Sergio Bertolín Puebla (@SergioBertolinSG)
-- Joas Schilling (@nickvergessen)
+See :doc:`Contributors <CONTRIBUTORS>`

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -29,8 +29,9 @@ sys.path.insert(0, os.path.abspath('../..'))
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-	'sphinx.ext.autodoc',
+    'sphinx.ext.autodoc',
     'sphinx.ext.coverage',
+    'sphinx.ext.intersphinx',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -46,8 +47,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Python ownCloud Client'
-copyright = u'2014, Vincent Petry'
+project = u'Python ownCloud Client Library'
+copyright = u'2016, Vincent Petry'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -199,7 +200,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  ('index', 'pyocclient.tex', u'Python ownCloud Client Documentation',
+  ('index', 'pyocclient.tex', u'Python ownCloud Client Library Documentation',
    u'Vincent Petry', 'manual'),
 ]
 
@@ -229,7 +230,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'owncloud', u'Python ownCloud Client Documentation',
+    ('index', 'owncloud', u'Python ownCloud Client Library Documentation',
      [u'Vincent Petry'], 1)
 ]
 
@@ -243,7 +244,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'ownCloudClient', u'Python ownCloud Client Documentation',
+  ('index', 'ownCloudClient', u'Python ownCloud Client Library Documentation',
    u'Vincent Petry', 'ownCloudClient', 'Python client library for ownCloud.',
    'Miscellaneous'),
 ]
@@ -259,3 +260,8 @@ texinfo_documents = [
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/2.7', None),
+}
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,7 +11,8 @@ Contents:
 .. toctree::
    :maxdepth: 2
 
-   owncloud
+   Description <README>
+   API Documentation <owncloud>
 
 Indices and tables
 ==================

--- a/docs/source/owncloud.rst
+++ b/docs/source/owncloud.rst
@@ -1,6 +1,18 @@
 owncloud package
 ================
 
+Submodules
+----------
+
+owncloud.owncloud module
+------------------------
+
+.. automodule:: owncloud.owncloud
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
 Module contents
 ---------------
 


### PR DESCRIPTION
Fixes https://github.com/owncloud/pyocclient/issues/149

Not sure whether it's ok to have all these email addresses in CONTRIBUTORS.md.
The ownCloud core project also does this, but in the case of pyocclient those would appear in the project documentation.

Do you know whether there is a best practice here for python projects ? @Gomez