### PR TITLE
link variable is now called url inside of shareinfo

### DIFF
--- a/owncloud/owncloud.py
+++ b/owncloud/owncloud.py
@@ -149,8 +149,8 @@ class ShareInfo():
         return None
 
     def get_link(self):
-        if 'link' in self.share_info:
-            return self.share_info['link']
+        if 'url' in self.share_info:
+            return self.share_info['url']
         return None
 
     def get_uid_owner(self):

--- a/owncloud/owncloud.py
+++ b/owncloud/owncloud.py
@@ -820,7 +820,7 @@ class Client():
                                 {
                                     'id': data_el.find('id').text,
                                     'path':path,
-                                    'link': data_el.find('url').text,
+                                    'url': data_el.find('url').text,
                                     'token': data_el.find('token').text
                                 }
             )


### PR DESCRIPTION
Perhaps it needs an addition for older versions. I'll add it if needed after travis.