### PR TITLE
add shared_with_me parameter to get_shares

### DIFF
--- a/owncloud/owncloud.py
+++ b/owncloud/owncloud.py
@@ -874,6 +874,8 @@ class Client():
             the current user but all shares from the given file (default: False)
         :param subfiles: (optional, boolean) returns all shares within
             a folder, given that path defines a folder (default: False)
+        :param shared_with_me: (optional, boolean) returns all shares which are
+            shared with me (default: False)
         :returns: array of shares ShareInfo instances or empty array if the operation failed
         :raises: HTTPResponseError in case an HTTP error status was returned
         """

--- a/owncloud/owncloud.py
+++ b/owncloud/owncloud.py
@@ -891,6 +891,12 @@ class Client():
             subfiles = kwargs.get('subfiles', False)
             if isinstance(subfiles, bool) and subfiles:
                 args['subfiles'] = str(subfiles).lower()
+
+            shared_with_me = kwargs.get('shared_with_me', False)
+            if isinstance(shared_with_me, bool) and shared_with_me:
+                args['shared_with_me'] = "true"
+                del args['path']
+
             data += urllib.urlencode(args)
 
         res = self.__make_ocs_request(

--- a/owncloud/test/test.py
+++ b/owncloud/test/test.py
@@ -602,6 +602,16 @@ class TestFileAccess(unittest.TestCase):
         self.assertEquals(share_info.get_path(), path)
         self.assertTrue(type(share_info.get_id()) is int)
         self.assertEquals(share_info.get_permissions(), 1)
+
+        shareclient = owncloud.Client(Config['owncloud_url'],
+                                      single_session=Config['single_session'])
+        shareclient.login(self.share2user, "share")
+        share2_info = shareclient.get_shares(
+            "/", shared_with_me=True)[0].share_info
+        self.assertEqual(share2_info["uid_owner"], Config['owncloud_login'])
+        self.assertEqual(file_name, share2_info["file_target"][1:])
+        shareclient.logout()
+
         self.assertTrue(self.client.delete(path))
 
     @data_provider(files)


### PR DESCRIPTION
adds shared_with_me argument for get_shares.

The URL parameter needs to be "true" in lowercase otherwise it fails with owncloud 9.0.3
see https://github.com/owncloud/core/issues/25411#issuecomment-231074750