### PR TITLE
Fixed reading of utf-8 formatted files in setup script.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,18 +3,19 @@
 # vim: expandtab shiftwidth=4 softtabstop=4
 #
 from setuptools import setup
+import io
 
 version = '0.4'
 
 long_description = (
-    open('README.rst').read()
+    io.open('README.rst', encoding='utf-8').read()
     + '\n' +
     'Contributors\n'
     '============\n'
     + '\n' +
-    open('docs/source/CONTRIBUTORS.rst').read()
+    io.open('docs/source/CONTRIBUTORS.rst', encoding='utf-8').read()
     + '\n' +
-    open('CHANGES.rst').read()
+    io.open('CHANGES.rst', encoding='utf-8').read()
     + '\n')
 
 setup(


### PR DESCRIPTION
This fix is to resolve [issue #196](https://github.com/owncloud/pyocclient/issues/196). In which the setup script is not property reading `utf-8` encoded files.
