### PR TITLE
Fix DeprecationWarning

### DIFF
--- a/owncloud/owncloud.py
+++ b/owncloud/owncloud.py
@@ -1841,7 +1841,7 @@ class Client(object):
         return_dict = {}
         for el in element:
             return_dict[el.tag] = None
-            children = el.getchildren()
+            children = list(el)
             if children:
                 return_dict[el.tag] = self._xml_to_dict(children)
             else:


### PR DESCRIPTION
- owncloud/owncloud.py:1844: DeprecationWarning: This method will be removed in
  future versions.  Use 'list(elem)' or iteration over elem instead.
  `children = el.getchildren()`

`./runtests.sh` does not report any errors