### PR TITLE
add oauth2 token to login

### DIFF
--- a/owncloud/owncloud.py
+++ b/owncloud/owncloud.py
@@ -345,18 +345,23 @@ class Client(object):
         self._capabilities = None
         self._version = None
 
-    def login(self, user_id, password):
+    def login(self, user_id=None, password=None, token=None):
         """Authenticate to ownCloud.
         This will create a session on the server.
 
         :param user_id: user id
         :param password: password
+        :param token: oauth2 token
         :raises: HTTPResponseError in case an HTTP error status was returned
         """
-
+        
         self._session = requests.session()
         self._session.verify = self._verify_certs
-        self._session.auth = (user_id, password)
+        
+        if user_id is None and password is None and token is not None and isinstance(token, str):
+            self._session.headers.update({"Authorization", "Bearer {}".format(token)})
+        else:
+            self._session.auth = (user_id, password)
 
         try:
             self._update_capabilities()


### PR DESCRIPTION
This PR adds the ability to login with the token from oauth2 workflow. Very small and easy edit.

It adds a parameter to the login function, so it is possible to call it either with user and password or token as string.

Through the default parameters it is backward compatible to previous implementations.