### PR TITLE
Fix from_public_link method

### DIFF
--- a/docs/source/README.rst
+++ b/docs/source/README.rst
@@ -128,7 +128,7 @@ Example for downloading a file from a public shared folder with password:
     public_link = 'http://domain.tld/owncloud/A1B2C3D4'
     folder_password = 'secret'
 
-    oc = owncloud.Client.from_public_link(public_link, password=folder_password)
+    oc = owncloud.Client.from_public_link(public_link, folder_password=folder_password)
     oc.get_file('/sharedfile.zip', 'download/destination/sharedfile.zip')
 
 Running the unit tests

--- a/owncloud/owncloud.py
+++ b/owncloud/owncloud.py
@@ -397,7 +397,9 @@ class Client(object):
     def from_public_link(cls, public_link, folder_password='', **kwargs):
         public_link_components = parse.urlparse(public_link)
         url = public_link_components.scheme + '://' + public_link_components.hostname
-        folder_token = public_link_components.path.split('/')[-1]       
+        if public_link_components.port:
+            url += f":{public_link_components.port}"
+        folder_token = public_link_components.path.split('/')[-1]
         anon_session = cls(url, **kwargs)
         anon_session.anon_login(folder_token, folder_password=folder_password)
         return anon_session


### PR DESCRIPTION
If you run your local version of owncloud using
```docker run -e OWNCLOUD_DOMAIN=localhost:8080 -p8080:8080 owncloud/server```

your shared links will have the following form: `"http://localhost:8080/s/<token>"`.
However, using such links in the `from_public_link` function didn't work before, since the url passed to the Client contstructor would be only "http://localhost".
This PR fixes this case and the url will be "http://localhost:8080".
It doesn't change the url if the port is None. 

---

Also the example in README.rst had a wrong name of the funcion's argument.

