### PR TITLE
Fix python2 support

### DIFF
--- a/owncloud/owncloud.py
+++ b/owncloud/owncloud.py
@@ -398,7 +398,7 @@ class Client(object):
         public_link_components = parse.urlparse(public_link)
         url = public_link_components.scheme + '://' + public_link_components.hostname
         if public_link_components.port:
-            url += f":{public_link_components.port}"
+            url += ":" + public_link_components.port
         folder_token = public_link_components.path.split('/')[-1]
         anon_session = cls(url, **kwargs)
         anon_session.anon_login(folder_token, folder_password=folder_password)


### PR DESCRIPTION
https://drone.owncloud.com/owncloud/smashbox-testing/1663/1/8
```
SUMMARY:smash.:Running iteration 1
SUMMARY:smash.:running /var/www/src/smashbox/test_reshareDir.py in /smashdir/test_reshareDir as test_reshareDir testset #0 {'use_new_dav_endpoint': False}
2021-10-14 09:30:33,499 - INFO - None - BEGIN SMASH RUN - rundir: /smashdir/test_reshareDir
2021-10-14 09:30:33,504 - INFO - None - reset_owncloud_account (delete) for 3 users
2021-10-14 09:30:33,504 - INFO - None - Deleting user test_reshareDir
Traceback (most recent call last):
  File "/smashbox/python/smashbox/multiprocessing_engine.py", line 317, in <module>
    _smash_.run()
  File "/smashbox/python/smashbox/multiprocessing_engine.py", line 188, in run
    smashbox.utilities.setup_test()
  File "/smashbox/python/smashbox/utilities/__init__.py", line 71, in setup_test
    reset_owncloud_account(num_test_users=config.oc_number_test_users)
  File "/smashbox/python/smashbox/utilities/__init__.py", line 117, in reset_owncloud_account
    delete_owncloud_account(config.oc_account_name)
  File "/smashbox/python/smashbox/utilities/__init__.py", line 220, in delete_owncloud_account
    oc_api = get_oc_api()
  File "/smashbox/python/smashbox/utilities/__init__.py", line 761, in get_oc_api
    import owncloud
  File "/smashbox/src/pyocclient/owncloud/__init__.py", line 5, in <module>
    from .owncloud import *
  File "/smashbox/src/pyocclient/owncloud/owncloud.py", line 401
    url += f":{public_link_components.port}"
                                           ^
SyntaxError: invalid syntax
SUMMARY:smash.:Elapsed time: 0s (0:0