### PR TITLE
Fix get shares with reshares

### DIFF
--- a/owncloud/owncloud.py
+++ b/owncloud/owncloud.py
@@ -977,7 +977,7 @@ class Client(object):
             args = {'path': path}
             reshares = kwargs.get('reshares', False)
             if isinstance(reshares, bool) and reshares:
-                args['reshares'] = reshares
+                args['reshares'] = str(reshares).lower()
             subfiles = kwargs.get('subfiles', False)
             if isinstance(subfiles, bool) and subfiles:
                 args['subfiles'] = str(subfiles).lower()


### PR DESCRIPTION
- OC 10.9.0 ignores 'True' as an url attribute value
- using the .lower() function fixed that problem