### PR TITLE
Update owncloud.py

### DIFF
--- a/owncloud/owncloud.py
+++ b/owncloud/owncloud.py
@@ -398,7 +398,7 @@ class Client(object):
         public_link_components = parse.urlparse(public_link)
         url = public_link_components.scheme + '://' + public_link_components.hostname
         if public_link_components.port:
-            url += ":" + public_link_components.port
+            url += ":" + str(public_link_components.port)
         folder_token = public_link_components.path.split('/')[-1]
         anon_session = cls(url, **kwargs)
         anon_session.anon_login(folder_token, folder_password=folder_password)


### PR DESCRIPTION
in `from_public_link`, if the URL contains a port number. There will be a runtime error because a `str` type is added by a `int` type.