### PR TITLE
Add share file with link expiration

### DIFF
--- a/owncloud/owncloud.py
+++ b/owncloud/owncloud.py
@@ -868,6 +868,7 @@ class Client(object):
         defaults to read only (1)
         :param public_upload (optional): allows users to upload files or folders
         :param password (optional): sets a password
+        :param expiredate (optional): sets an expiration date for the shared link
         https://doc.owncloud.com/server/next/admin_manual/configuration/files/file_sharing_configuration.html
         :param name (optional): display name for the link
         :returns: instance of :class:`ShareInfo` with the share info

--- a/owncloud/owncloud.py
+++ b/owncloud/owncloud.py
@@ -877,6 +877,7 @@ class Client(object):
         perms = kwargs.get('perms', None)
         public_upload = kwargs.get('public_upload', 'false')
         password = kwargs.get('password', None)
+        expiredate = kwargs.get('expiredate', None)
         name = kwargs.get('name', None)
 
         path = self._normalize_path(path)
@@ -888,6 +889,8 @@ class Client(object):
             post_data['publicUpload'] = str(public_upload).lower()
         if isinstance(password, six.string_types):
             post_data['password'] = password
+        if isinstance(expiredate, datetime.date):
+            post_data['expireDate'] = expiredate
         if name is not None:
             post_data['name'] = self._encode_string(name)
         if perms:

--- a/owncloud/owncloud.py
+++ b/owncloud/owncloud.py
@@ -398,7 +398,7 @@ class Client(object):
         public_link_components = parse.urlparse(public_link)
         url = public_link_components.scheme + '://' + public_link_components.hostname
         if public_link_components.port:
-            url += ":" + public_link_components.port
+            url += ":" + str(public_link_components.port)
         folder_token = public_link_components.path.split('/')[-1]
         anon_session = cls(url, **kwargs)
         anon_session.anon_login(folder_token, folder_password=folder_password)

--- a/owncloud/owncloud.py
+++ b/owncloud/owncloud.py
@@ -868,7 +868,7 @@ class Client(object):
         defaults to read only (1)
         :param public_upload (optional): allows users to upload files or folders
         :param password (optional): sets a password
-        :param expiredate (optional): sets an expiration date for the shared link
+        :param expire_date (optional): sets an expiration date for the shared link
         https://doc.owncloud.com/server/next/admin_manual/configuration/files/file_sharing_configuration.html
         :param name (optional): display name for the link
         :returns: instance of :class:`ShareInfo` with the share info
@@ -878,7 +878,7 @@ class Client(object):
         perms = kwargs.get('perms', None)
         public_upload = kwargs.get('public_upload', 'false')
         password = kwargs.get('password', None)
-        expiredate = kwargs.get('expiredate', None)
+        expire_date = kwargs.get('expire_date', None)
         name = kwargs.get('name', None)
 
         path = self._normalize_path(path)
@@ -890,8 +890,8 @@ class Client(object):
             post_data['publicUpload'] = str(public_upload).lower()
         if isinstance(password, six.string_types):
             post_data['password'] = password
-        if isinstance(expiredate, datetime.date):
-            post_data['expireDate'] = expiredate
+        if isinstance(expire_date, datetime.date):
+            post_data['expireDate'] = expire_date
         if name is not None:
             post_data['name'] = self._encode_string(name)
         if perms:

--- a/owncloud/owncloud.py
+++ b/owncloud/owncloud.py
@@ -913,7 +913,14 @@ class Client(object):
                                     'path': path,
                                     'url': data_el.find('url').text,
                                     'token': data_el.find('token').text,
-                                    'name': data_el.find('name').text
+                                    'name': data_el.find('name').text,
+                                    "expiration": int(
+                                        round(
+                                            datetime.datetime.strptime(
+                                                data_el.find("expiration").text, "%Y-%m-%d %H:%M:%S"
+                                            ).timestamp()
+                                        )
+                                    ),
                                 }
             )
         raise HTTPResponseError(res)

--- a/owncloud/owncloud.py
+++ b/owncloud/owncloud.py
@@ -907,6 +907,17 @@ class Client(object):
             tree = ET.fromstring(res.content)
             self._check_ocs_status(tree)
             data_el = tree.find('data')
+            exp_el = data_el.find('expiration')
+            expiration = None
+            if exp_el is not None:
+                if exp_el.text is not None:
+                    expiration = int(
+                        round(
+                            datetime.datetime.strptime(
+                                exp_el.text, "%Y-%m-%d %H:%M:%S"
+                            ).timestamp()
+                        )
+                    )
             return ShareInfo(
                                 {
                                     'id': data_el.find('id').text,
@@ -914,13 +925,7 @@ class Client(object):
                                     'url': data_el.find('url').text,
                                     'token': data_el.find('token').text,
                                     'name': data_el.find('name').text,
-                                    "expiration": int(
-                                        round(
-                                            datetime.datetime.strptime(
-                                                data_el.find("expiration").text, "%Y-%m-%d %H:%M:%S"
-                                            ).timestamp()
-                                        )
-                                    ),
+                                    "expiration": expiration,
                                 }
             )
         raise HTTPResponseError(res)

--- a/owncloud/test/test.py
+++ b/owncloud/test/test.py
@@ -713,7 +713,8 @@ class TestFileAccess(unittest.TestCase):
         path = self.test_root + file_name
         self.assertTrue(self.client.put_file_contents(path, 'hello world!'))
 
-        share_info = self.client.share_file_with_link(path, public_upload=False, password='AnvvsP1234', name='Test Link')
+        tomorrow = datetime.datetime.now() + datetime.timedelta(days=1)
+        share_info = self.client.share_file_with_link(path, public_upload=False, password='AnvvsP1234', name='Test Link', expire_date=tomorrow.date())
 
         self.assertTrue(self.client.is_shared(path))
         self.assertTrue(isinstance(share_info, owncloud.ShareInfo))
@@ -722,6 +723,8 @@ class TestFileAccess(unittest.TestCase):
         self.assertEqual(share_info.get_name(), 'Test Link')
         self.assertTrue(type(share_info.get_link()) is str)
         self.assertTrue(type(share_info.get_token()) is str)
+        self.assertTrue(type(share_info.get_expiration()) is datetime.datetime)
+
 
     def test_share_with_link_non_existing_file(self):
         """Test sharing a file with link"""


### PR DESCRIPTION
Hi, this expands on #287 (I wasn't sure how to modify the existing PR...). 

This PR includes the following:
- Snake case the expiredate kwarg to expire_date
- expiration added to ShareInfo object returned by {Client}.share_file_with_link
- test_share_with_link() has been expanded to include an expire_date.

When running the test suite TestPublicFolder.test_from_link kept failing with the error `TypeError: can only concatenate str (not "int") to str` due to [line 401](https://github.com/owncloud/pyocclient/blob/1eec85496cd547271f37796e2fba75eaac725185/owncloud/owncloud.py#L401) so I added str(public_link_components.port).

This PR closes #287 and it closes #289.

Edit. I just noticed the last point is addressed by issue #291. So this PR overlaps and also closes #290 and closes #291.